### PR TITLE
Add GitHub Skills activity (fixes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub, part of the GitHub Certifications program",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 30,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the missing **GitHub Skills** activity to the extracurricular activities list.

## Changes

- Added "GitHub Skills" entry to the in-memory `activities` dictionary in `app.py`
  - **Description**: Learn practical coding and collaboration skills using GitHub, part of the GitHub Certifications program
  - **Schedule**: Mondays and Wednesdays, 3:30 PM - 4:30 PM
  - **Max participants**: 30
  - **Participants**: Empty (ready for signups)

## Resolves

Closes #6 — The GitHub Skills activity announced by the principal is now available for student registration on the website.